### PR TITLE
convert to UTC before serializing

### DIFF
--- a/addon/transforms/luxon-date-time-utc.js
+++ b/addon/transforms/luxon-date-time-utc.js
@@ -11,10 +11,10 @@ export default Transform.extend({
   },
 
   serialize(deserialized) {
-    if (deserialized === null) {
+    if (!deserialized) {
       return deserialized;
     }
 
-    return deserialized.toISO();
+    return deserialized.toUTC().toISO();
   },
 });


### PR DESCRIPTION
convert to UTC before serializing, and loosen up the check (because it may be undefined instead of just null)